### PR TITLE
Fix allowed statuses not being fetched correctly

### DIFF
--- a/Taskodrome/pages/main.php
+++ b/Taskodrome/pages/main.php
@@ -60,7 +60,7 @@
       $issues_array_html .= 'updateTime="'.$t_row->last_updated.'"';
       $issues_array_html .= '></p>';
 
-      $t_all_statuses = get_status_option_list(access_get_project_level( $t_row->project_id ), 0, true, false, $t_row->project_id);
+      $t_all_statuses = get_status_option_list(access_get_project_level( $t_row->project_id ), $t_row->status, true, false, $t_row->project_id);
 
       $allowed_statuses_html .= '<p hidden="true" class="status_pair" ';
       $allowed_statuses_html .= 'id="' . $t_row->id . '" ';


### PR DESCRIPTION
Recently, a fix for #41 was introduced. This fix added some more arguments to the `get_status_option_list` call where the allowed statuses for an issue are computed. However, it always uses the constant `0` for the second argument. This argument is, in [MantisBT's PHPDoc for that method](https://github.com/mantisbt/mantisbt/blob/1f8e3b70bb40ec0b8f02d253d197c19041fcae0f/core/print_api.php\#L992) described as "The current value", which seems to mean the current status of the issue. <sup>[1](https://github.com/mantisbt/mantisbt/blob/8daee923590e0e99ccdf25080efb6248a8aef990/bug_report_page.php#L489)</sup> This causes the application to create flawed output, such as that depicted in the screenshot below.

![screenshot_2016-09-15_23-11-16](https://cloud.githubusercontent.com/assets/547070/18568643/6f4594fa-7b9e-11e6-8c2d-64d1b4623da3.png)

This PR fixes this issue by replacing the constant by the number of the issue in question. I have tested the change on my system (MantisBT 1.3.0-rc.2), where it fixes the issue outlined in #41 . After this, I can drag and drop cards in the status board, which is awesome.

I see that there's a master and two versioned branches, I hope that this is for the correct branch.

Thanks!