### PR TITLE
Fix allowed statuses not being fetched correctly

### DIFF
--- a/Taskodrome/pages/main.php
+++ b/Taskodrome/pages/main.php
@@ -60,7 +60,7 @@
       $issues_array_html .= 'updateTime="'.$t_row->last_updated.'"';
       $issues_array_html .= '></p>';
 
-      $t_all_statuses = get_status_option_list(access_get_project_level( $t_row->project_id ), 0, true, false, $t_row->project_id);
+      $t_all_statuses = get_status_option_list(access_get_project_level( $t_row->project_id ), $t_row->status, true, false, $t_row->project_id);
 
       $allowed_statuses_html .= '<p hidden="true" class="status_pair" ';
       $allowed_statuses_html .= 'id="' . $t_row->id . '" ';


### PR DESCRIPTION
According to https://github.com/mantisbt/mantisbt/blob/1f8e3b70bb40ec0b8f02d253d197c19041fcae0f/core/print_api.php\#L992,
the seconds parameter for the get_status_option_list method is the current status.
However, in the current implementation it is set to constant 0, which causes
the function to get confused and makes it always return 0.

This commit fixes that.