### PR TITLE
Re-add menu icon for MantisBT 2.0

### DIFF
--- a/Taskodrome/Taskodrome.php
+++ b/Taskodrome/Taskodrome.php
@@ -28,6 +28,17 @@ class TaskodromePlugin extends MantisPlugin
     );
   }
 
+  public function menu()
+  {
+    $links = array();
+    $links[] = array(
+      'title' => plugin_lang_get("board"),
+      'url' => plugin_page("main"),
+      'icon' => 'fa-columns'
+    );
+    return $links;
+  }
+
   public function config()
   {
     $status_list = explode(',', lang_get( 'status_enum_string' ));


### PR DESCRIPTION
This PR re-adds the Taskodrome menu icon that was removed with the 2.0 update. To make this work, I looked at how the source-integration plugin does this and adapted their approach to the needs of this project. The columns icon was the most fitting I could find, although another one can be selected from http://fontawesome.io/icons/.