### PR TITLE
Re-add menu icon for MantisBT 2.0

### DIFF
--- a/Taskodrome/Taskodrome.php
+++ b/Taskodrome/Taskodrome.php
@@ -28,6 +28,17 @@ class TaskodromePlugin extends MantisPlugin
     );
   }
 
+  public function menu()
+  {
+    $links = array();
+    $links[] = array(
+      'title' => plugin_lang_get("board"),
+      'url' => plugin_page("main", true),
+      'icon' => 'fa-columns'
+    );
+    return $links;
+  }
+
   public function config()
   {
     $status_list = explode(',', lang_get( 'status_enum_string' ));


### PR DESCRIPTION
This PR re-adds the Taskodrome menu icon that was removed with the 2.0 update. To make this work, I looked at [how the source-integration plugin does this](https://github.com/mantisbt-plugins/source-integration/blob/master/Source/Source.php) and adapted their approach to the needs of this project. The columns icon was the most fitting I could find, although another one can be selected from http://fontawesome.io/icons/.

Contrary to #89, the URL on this one is relative to the installation and does not try to redirect to https://plugin.php/

Here's a screenshot:
![2017-01-16_10 01 13](https://cloud.githubusercontent.com/assets/547070/21977883/7a917de8-dbd8-11e6-85ac-359bf510714a.png)
