### PR TITLE
Use mbstring functions instead of deprecated utf8 functions

### DIFF
--- a/Taskodrome/pages/main.php
+++ b/Taskodrome/pages/main.php
@@ -251,14 +251,14 @@
     $t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
     foreach( $t_users as $t_key => $t_user ) {
       $t_user_name = string_attribute( $t_user['username'] );
-      $t_sort_name = utf8_strtolower( $t_user_name );
+      $t_sort_name = mb_strtolower( $t_user_name );
       if( $t_show_realname && ( $t_user['realname'] <> '' ) ) {
         $t_user_name = string_attribute( $t_user['realname'] );
         if( $t_sort_by_last_name ) {
-          $t_sort_name_bits = explode( ' ', utf8_strtolower( $t_user_name ), 2 );
+          $t_sort_name_bits = explode( ' ', mb_strtolower( $t_user_name ), 2 );
           $t_sort_name = ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
         } else {
-          $t_sort_name = utf8_strtolower( $t_user_name );
+          $t_sort_name = mb_strtolower( $t_user_name );
         }
       }
 


### PR DESCRIPTION
utf8 functions like utf8_strlen will be deprecated in MantisBT 2.13.0 [1]

The functions are still supported but will generate DEPRCECATED messages in PHP logs.
The functions are no longer needed as we made `mbstring` a mandatory PHP extension.

[1] https://mantisbt.org/bugs/view.php?id=23214